### PR TITLE
Initialized "ambient_file" to avoid errors with irregular file names.

### DIFF
--- a/R/functions/neet_calc_wav.R
+++ b/R/functions/neet_calc_wav.R
@@ -7,6 +7,8 @@ neet_wav <- function(filename, PAR=NULL, fluxfiles,
                      SS_thresh = 90.0,
                      par_thresh = 650){
   
+  ambient_file <- "N/A"
+  
   
   suppressMessages(suppressWarnings(
     LI_dat <- read_delim(filename, delim="\t", skip = licor_skip)))


### PR DESCRIPTION
Simple fix for flux files with irregular names causing errors due to the inability to find corresponding ambient measurement.